### PR TITLE
add support for inline forms

### DIFF
--- a/src/inline-form/index.js
+++ b/src/inline-form/index.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import InlineFormWrapper from './style';
+
+const InlineForm = ({ children, ...rest }) => (
+  <InlineFormWrapper {...rest}>{children}</InlineFormWrapper>
+);
+
+InlineForm.propTypes = {
+  children: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.node),
+    PropTypes.node
+  ]).isRequired
+};
+
+export default InlineForm;

--- a/src/inline-form/style.js
+++ b/src/inline-form/style.js
@@ -1,0 +1,26 @@
+import styled from 'styled-components';
+
+export default styled.form`
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  justify-content: center;
+
+  & div {
+    border-radius: 4px 0 0 4px;
+    & input {
+      padding: 9px 15px;
+    }
+  }
+
+  & button {
+    border-radius: 0 4px 4px 0;
+    box-shadow: none;
+    height: 100%;
+    margin: 0;
+    &:hover {
+      bottom: 0;
+      box-shadow: none;
+    }
+  }
+`;

--- a/stories/forms.js
+++ b/stories/forms.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import { boolean, select, text } from '@storybook/addon-knobs';
+import { boolean } from '@storybook/addon-knobs';
 import { action } from '@storybook/addon-actions';
 
 import Input from '../src/input';
-import Dropdown from '../src/dropdown';
 
 import { FormFieldLabel } from '../src/form';
+import InlineForm from '../src/inline-form/index';
+import Button from '../src/button/index';
 
 storiesOf('Forms', module)
   .add('Input', () => (
@@ -36,4 +37,13 @@ storiesOf('Forms', module)
       placeholder='Disabled'
       disabled
     />
+  ))
+  .add('Inline Form', () => (
+    <InlineForm>
+      <Input
+        input={{ value: '', onChange: () => console.log('input') }}
+        placeholder='Placeholder'
+      />
+      <Button>Search</Button>
+    </InlineForm>
   ));


### PR DESCRIPTION
This adds basic support for inline forms with an input on the left
and a button on the right.

<img width="326" alt="Screenshot 2019-05-09 at 11 30 34" src="https://user-images.githubusercontent.com/743964/57443248-ea45c500-724d-11e9-9c8f-114e0f19f137.png">