### PR TITLE
CI: inject git branch to Docker

### DIFF
--- a/.buildkite/ci.sh
+++ b/.buildkite/ci.sh
@@ -4,4 +4,4 @@
 set -euxo pipefail
 
 docker build -t oxygen .
-docker run -e GH_TOKEN=${GH_TOKEN} -e NPM_TOKEN=${NPM_TOKEN} oxygen
+docker run -e GH_TOKEN=${GH_TOKEN} -e NPM_TOKEN=${NPM_TOKEN} -e GIT_BRANCH={BUILDKITE_BRANCH} oxygen


### PR DESCRIPTION
It seems that semantic-release uses an environment variable `GIT_BRANCH` which must be auto injected locally but not on Buildkite. Seeing if this helps.