### PR TITLE
CI: fix git install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM node:10-alpine as build
 
-RUN apk add --no-cache git
+RUN apk add --no-cache bash git openssh
 
 # Install
 WORKDIR /app


### PR DESCRIPTION
The release requires ssh which isn't installed on alpine. Adding bash because.