### PR TITLE
input and button styles closer aligned to invision designs

### DIFF
--- a/src/button/style.js
+++ b/src/button/style.js
@@ -6,7 +6,7 @@ const BoxShadow = css`
 
   @media (hover: hover) {
     &:hover {
-      bottom: 1px;
+      transform: translateY(-1px);
       box-shadow: 0 11px 9px -1px rgba(0, 0, 0, 0.06),
         0 5px 6px -1px rgba(0, 0, 0, 0.15);
     }
@@ -19,11 +19,13 @@ const Disabled = css`
 `;
 
 const SmallButton = css`
-  padding: 7px 12px 7px;
+  height: 38px;
+  padding: 0 12px;
 `;
 
 const LargeButton = css`
-  padding: 16px 20px 16px;
+  height: 55px;
+  padding: 0 24px;
 `;
 
 const PrimaryButton = css`
@@ -61,26 +63,28 @@ const SuccessButton = css`
 `;
 
 const ButtonStyle = css`
-  bottom: 0;
   border-radius: 4px;
   cursor: pointer;
-  display: inline-block;
-  font: 400 15px 'Source Sans Pro', sans-serif;
-  line-height: 1;
-  margin: 4px;
+  font-size: 15px;
+  font-weight: 600;
+  line-height: 19px;
   outline: none;
-  padding: 11px 16px 10px;
+  height: 44px;
+  padding: 0 16px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: relative;
-  text-align: center;
-  text-decoration: none;
-  transition: all 0.1s ease-out;
+  transform: translateY(0);
+  transition: transform 0.1s ease-out;
+  max-width: 380px;
 
   ${({ variant }) => (variant !== 'text' ? BoxShadow : 'none')};
 
   & > svg {
-    float: right;
+    position: absolute;
+    right: 12px;
     height: 20px;
-    margin: -2px -5px -5px 2px;
     width: 20px;
   }
 
@@ -112,6 +116,7 @@ const ButtonStyle = css`
 
 export const StyledLinkButton = styled.a`
   ${ButtonStyle}
+  text-decoration: none;
 `;
 
 export const StyledButton = styled.button`

--- a/src/colors.js
+++ b/src/colors.js
@@ -25,5 +25,6 @@ export default {
   darkbg: '#f0f0f8',
 
   monteCarlo: '#87ccd4',
-  paradiso: '#398891'
+  paradiso: '#398891',
+  ghost: '#C9C9D1'
 };

--- a/src/input/index.js
+++ b/src/input/index.js
@@ -64,7 +64,7 @@ class Input extends React.PureComponent {
     } = this.props;
 
     return (
-      <React.Fragment>
+      <div>
         <Container
           warning={showWarning(meta)}
           active={meta.active}
@@ -98,7 +98,7 @@ class Input extends React.PureComponent {
           )}
         </Container>
         {showError(meta) && <ErrorMessage>{meta.error}</ErrorMessage>}
-      </React.Fragment>
+      </div>
     );
   }
 }

--- a/src/input/style.js
+++ b/src/input/style.js
@@ -25,8 +25,8 @@ export const TextInput = styled.input`
   background: transparent;
 
   &::placeholder {
-    font-size: 14px;
-    color: ${colors.grey};
+    font-size: 15px;
+    color: ${colors.ghost};
   }
 
   ${({ disabled }) => disabled && TextInputDisabled};
@@ -49,10 +49,10 @@ const ContainerDisabled = css`
 
 export const Container = styled.div`
   border: ${({ noBorder }) => (noBorder ? 'none' : `1px solid ${colors.grey}`)};
-  box-shadow: ${({ noShadow }) =>
-    noShadow ? 'none' : 'inset 0 2px 4px 0 rgba(65,65,96,0.18)'};
   border-radius: 4px;
   display: flex;
+  box-shadow: inset 0 1px 1px 0 rgba(65, 65, 96, 0.18);
+  background-color: ${colors.white};
 
   flex-grow: ${({ flexGrow }) => flexGrow || '0'};
   ${({ active }) => active && ContainerActive};


### PR DESCRIPTION
# Buttons
Quite a few changes to styles but outcome is the same.
- Use `transform` to move button around, not a big fan of adjusting `bottom` to move the button upwards. This would move all content along with it, rather than just the button.
- Absolute positioning of the icon to always be on the far right of the button (respecting the padding). I'm willing to discuss this one if we want to keep the `float` property. Just haven't seen / used that in ages.
- Don't want to set the font-family here -- this should use whatever is set on the site it's being used on. Set the font styles individually and match invision designs.
- `max-width` of `380px` by default. This can be overridden if necessary.
![image](https://user-images.githubusercontent.com/5119031/62469982-ab1a0800-b799-11e9-9753-ea1b386d1e62.png)

# Inputs
- Better placeholder colour.
- Less inset box shadow 🥇
![image](https://user-images.githubusercontent.com/5119031/62470395-a570f200-b79a-11e9-9958-f6aaa17894dd.png)
- Replace `Fragment` with div. Without it validation errors just fly around randomly depending on what parent styles are and this component shouldn't be affected by it.
![image](https://user-images.githubusercontent.com/5119031/62470452-bfaad000-b79a-11e9-8e20-64ef7961eeca.png)

