### PR TITLE
allow custom url on header and link component

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-router-dom": "^4.3.1",
-    "storybook-react-router": "^1.0.5",
     "styled-components": "^4.2.0",
     "styled-icons": "^7.14.0"
   },
@@ -73,6 +72,7 @@
     "husky": "^1.3.1",
     "rimraf": "^2.6.3",
     "semantic-release": "^15.13.19",
+    "storybook-react-router": "^1.0.5",
     "webpack": "^4.32.0",
     "webpack-cli": "^3.3.2"
   },

--- a/src/button/style.js
+++ b/src/button/style.js
@@ -1,4 +1,5 @@
 import styled, { css } from 'styled-components';
+import Link from '../link';
 import colors from '../colors';
 
 const BoxShadow = css`
@@ -122,7 +123,7 @@ const ButtonStyle = css`
   }};
 `;
 
-export const StyledLinkButton = styled.a`
+export const StyledLinkButton = styled(Link)`
   ${ButtonStyle}
   text-decoration: none;
 `;

--- a/src/header-with-breadcrumbs/index.js
+++ b/src/header-with-breadcrumbs/index.js
@@ -3,9 +3,14 @@ import PropTypes from 'prop-types';
 
 import { StyledHeader as Header, Step, Crumbs } from './style';
 
-const HeaderWithBreadcrumbs = ({ className, crumbs, activeIndex }) => {
+const HeaderWithBreadcrumbs = ({
+  className,
+  crumbs,
+  activeIndex,
+  logoLink
+}) => {
   return (
-    <Header className={className}>
+    <Header className={className} logoLink={logoLink}>
       <Crumbs>
         {crumbs.map((crumb, index) => (
           <Step
@@ -23,13 +28,15 @@ const HeaderWithBreadcrumbs = ({ className, crumbs, activeIndex }) => {
 
 HeaderWithBreadcrumbs.defaultProps = {
   className: null,
-  activeIndex: 0
+  activeIndex: 0,
+  logoLink: '/'
 };
 
 HeaderWithBreadcrumbs.propTypes = {
   className: PropTypes.string,
   crumbs: PropTypes.arrayOf(PropTypes.string).isRequired,
-  activeIndex: PropTypes.number
+  activeIndex: PropTypes.number,
+  logoLink: PropTypes.string
 };
 
 export default HeaderWithBreadcrumbs;

--- a/src/header/index.js
+++ b/src/header/index.js
@@ -8,11 +8,11 @@ import {
   StyledLink
 } from './style';
 
-const Header = ({ logo: Logo, children, ...rest }) => (
+const Header = ({ logo: Logo, logoLink, children, ...rest }) => (
   <HeaderContainer {...rest}>
     {Logo && <Logo />}
     {!Logo && (
-      <StyledLink to='/'>
+      <StyledLink to={logoLink}>
         <SmallLeadhomeLogo />
         <LeadhomeLogo />
       </StyledLink>
@@ -21,8 +21,13 @@ const Header = ({ logo: Logo, children, ...rest }) => (
   </HeaderContainer>
 );
 
+Header.defaultProps = {
+  logoLink: '/'
+};
+
 Header.propTypes = {
   logo: PropTypes.func,
+  logoLink: PropTypes.string,
   children: PropTypes.oneOfType([PropTypes.string, PropTypes.object])
 };
 

--- a/src/header/style.js
+++ b/src/header/style.js
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import colors from '../colors';
 
-import { Link } from 'react-router-dom';
+import Link from '../link';
 import { ReactComponent as LeadhomeSVG } from '../../assets/leadhome-logo.svg';
 import { ReactComponent as SmallLeadhomeSVG } from '../../assets/leadhome-logo-small.svg';
 

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import Toast from './toast';
 import CardBody from './card-body';
 import CardFooter from './card-footer';
 import PropertyCard from './property-card';
+import Link from './link';
 
 export {
   Button,
@@ -26,5 +27,6 @@ export {
   Footer,
   AutoComplete,
   Toast,
-  PropertyCard
+  PropertyCard,
+  Link
 };

--- a/src/link/index.js
+++ b/src/link/index.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link as ReactRouterLink } from 'react-router-dom';
+
+// eslint-disable-next-line no-useless-escape
+const linkRegex = /^(http:\/\/www\.|https:\/\/www\.|http:\/\/|https:\/\/)?[a-z0-9]+([\-\.]{1}[a-z0-9]+)*\.[a-z]{2,5}(:[0-9]{1,5})?(\/.*)?$/;
+
+const Link = ({ children, href, ...rest }) => {
+  const isExternal = linkRegex.test(href);
+
+  return (
+    (isExternal && (
+      <a href={href} {...rest}>
+        {children}
+      </a>
+    )) || (
+      <ReactRouterLink to={href} {...rest}>
+        {children}
+      </ReactRouterLink>
+    )
+  );
+};
+
+Link.propTypes = {
+  children: PropTypes.node.isRequired,
+  href: PropTypes.string.isRequired
+};
+
+export default Link;

--- a/stories/header.js
+++ b/stories/header.js
@@ -1,21 +1,31 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { select, text } from '@storybook/addon-knobs';
+import StoryRouter from 'storybook-react-router';
+
 import Header from '../src/header';
-import { ReactComponent as LeadhomeLogo } from '../assets/leadhome-logo.svg';
 import { ReactComponent as BugLogo } from '../assets/bug.svg';
 
-const logos = { undefined, BugLogo, LeadhomeLogo };
+const logos = { undefined, BugLogo };
+const stories = storiesOf('Header', module);
+stories.addDecorator(StoryRouter());
+stories.add('Default', () => <Header />);
 
-storiesOf('Header', module).add('Header', () => {
-  const logo = select('Logo', Object.keys(logos), 'BugLogo');
-
-  console.log(logo);
-
+stories.add('WithChildren', () => {
   return (
-    <Header logo={logos[logo]}>
+    <Header>
       {text('child1', '1st child ')}
       {text('child2', '2nd child')}
     </Header>
   );
+});
+
+stories.add('WithCustomLogo', () => {
+  const logo = select('Logo', Object.keys(logos), 'BugLogo');
+  return <Header logo={logos[logo]} />;
+});
+
+stories.add('WithLogoLink', () => {
+  const link = text('LogoLink', 'https://leadhome.co.za');
+  return <Header logoLink={link} />;
 });


### PR DESCRIPTION
- Move `storybook-react-router` to dev dependencies.
- Created link component to automatically use `a` when the link is not relative, meaning it shouldn't use `react-router-dom`
- Updated `header` component to allow a custom url.