### PR TITLE
(fix): safari chevron

### DIFF
--- a/src/button/style.js
+++ b/src/button/style.js
@@ -94,6 +94,7 @@ export const ButtonStyle = css`
   > svg {
     position: absolute;
     right: 16px;
+    top: calc(50% - 20px);
     height: 20px;
     width: 20px;
   }


### PR DESCRIPTION
Doesn't seem to mess with other browsers and makes it work in Safari